### PR TITLE
Don't call the getFileStream continuation multiple times for large files.

### DIFF
--- a/app/coffee/FSPersistorManager.coffee
+++ b/app/coffee/FSPersistorManager.coffee
@@ -37,8 +37,7 @@ module.exports =
         callback null, response().html('NoSuchKey: file not found\n')
       else
         callback err
-    sourceStream.on 'readable', () ->
-      callback null, sourceStream
+    callback null, sourceStream
 
 
   copyFile: (location, fromName, toName, callback = (err)->)->


### PR DESCRIPTION
Currently, large files get corrupted when they are retrieved from the filesystem filestore. See https://twitter.com/AndreaHawksley/status/570332991810981888

The root cause is that `FSPersitorManager.getFileStream` invokes its continuation `callback` multiple times, because the `"readable"` event occurs multiple times (see http://nodejs.org/api/stream.html#stream_event_readable).

The fix is to ensure that the callback is only invoked once.

Unfortunately, it looks like this undoes some of the intended effects of the commit that introduced the bug:
 https://github.com/sharelatex/filestore-sharelatex/commit/af19716f9a886b05fc127a1179991c86a5e336bb
I'm not sure what the right way would be to preserve that intended behavior.
