### PR TITLE
Provide hosts as environment settings and add npm run start script

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -4,7 +4,7 @@ module.exports =
 	internal:
 		filestore:
 			port: 3009
-			host: "localhost"
+			host: process.env['LISTEN_ADDRESS'] or "localhost"
 
 	filestore:
 		# Which backend persistor to use.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/sharelatex/filestore-sharelatex.git"
   },
+  "scripts": {
+    "compile:app": "coffee -o app/js -c app/coffee && coffee -c app.coffee",
+    "start": "npm run compile:app && node app.js"
+  },
   "dependencies": {
     "async": "~0.2.10",
     "aws-sdk": "^2.1.39",


### PR DESCRIPTION
Makes this service compatible with https://github.com/sharelatex/sharelatex-dev-environment

Allows other service's locations to be passed in via environment variables which are provided by docker-compose.

Also provides an `npm run start` script as a common entry point to all services via docker-compose.