### PR TITLE
Add endpoint for arbitrary bucket fetch

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -4,6 +4,7 @@ logger.initialize("filestore")
 settings = require("settings-sharelatex")
 request = require("request")
 fileController = require("./app/js/FileController")
+bucketController = require("./app/js/BucketController")
 keyBuilder = require("./app/js/KeyBuilder")
 healthCheckController = require("./app/js/HealthCheckController")
 domain = require("domain")
@@ -18,7 +19,7 @@ Metrics.memory.monitor(logger)
 
 app.configure ->
 	app.use Metrics.http.monitor(logger)
-	
+
 app.configure 'development', ->
 	console.log "Development Enviroment"
 	app.use express.errorHandler({ dumpExceptions: true, showStack: true })
@@ -86,6 +87,8 @@ app.del "/project/:project_id/public/:public_file_id", keyBuilder.publicFileKey,
 
 app.get "/project/:project_id/size", keyBuilder.publicProjectKey, fileController.directorySize
 
+app.get "/bucket/:bucket/key/*", bucketController.getFile
+
 app.get "/heapdump", (req, res)->
 	require('heapdump').writeSnapshot '/tmp/' + Date.now() + '.filestore.heapsnapshot', (err, filename)->
 		res.send filename
@@ -103,8 +106,6 @@ app.get '/status', (req, res)->
 
 
 app.get "/health_check", healthCheckController.check
-	
-
 
 
 app.get '*', (req, res)->

--- a/app/coffee/BucketController.coffee
+++ b/app/coffee/BucketController.coffee
@@ -7,8 +7,8 @@ Errors = require('./Errors')
 module.exports = BucketController =
 
 	getFile: (req, res)->
-		{bucket} = req
-		key = req[0]
+		{bucket} = req.params
+		key = req.params[0]
 		{format, style} = req.query
 		credentials = settings.filestore.s3&[bucket]
 		options = {

--- a/app/coffee/BucketController.coffee
+++ b/app/coffee/BucketController.coffee
@@ -1,13 +1,8 @@
-PersistorManager = require("./PersistorManager")
 settings = require("settings-sharelatex")
 logger = require("logger-sharelatex")
 FileHandler = require("./FileHandler")
 metrics = require("metrics-sharelatex")
-parseRange = require('range-parser')
 Errors = require('./Errors')
-
-oneDayInSeconds = 60 * 60 * 24
-maxSizeInBytes = 1024 * 1024 * 1024 # 1GB
 
 module.exports = BucketController =
 
@@ -21,7 +16,7 @@ module.exports = BucketController =
 			bucket: bucket,
 			credentials: credentials
 		}
-		metrics.inc "getFile"
+		metrics.inc "#{bucket}.getFile"
 		logger.log key:key, bucket:bucket, "receiving request to get file from bucket"
 		FileHandler.getFile bucket, key, options, (err, fileStream)->
 			if err?
@@ -33,4 +28,3 @@ module.exports = BucketController =
 			else
 				logger.log key:key, bucket:bucket, format:format, style:style, "sending bucket file to response"
 				fileStream.pipe res
-

--- a/app/coffee/BucketController.coffee
+++ b/app/coffee/BucketController.coffee
@@ -9,7 +9,6 @@ module.exports = BucketController =
 	getFile: (req, res)->
 		{bucket} = req.params
 		key = req.params[0]
-		{format, style} = req.query
 		credentials = settings.filestore.s3[bucket]
 		options = {
 			key: key,
@@ -20,11 +19,11 @@ module.exports = BucketController =
 		logger.log key:key, bucket:bucket, "receiving request to get file from bucket"
 		FileHandler.getFile bucket, key, options, (err, fileStream)->
 			if err?
-				logger.err err:err, key:key, bucket:bucket, format:format, style:style, "problem getting file from bucket"
+				logger.err err:err, key:key, bucket:bucket, "problem getting file from bucket"
 				if err instanceof Errors.NotFoundError
 					return res.send 404
 				else
 					return res.send 500
 			else
-				logger.log key:key, bucket:bucket, format:format, style:style, "sending bucket file to response"
+				logger.log key:key, bucket:bucket, "sending bucket file to response"
 				fileStream.pipe res

--- a/app/coffee/BucketController.coffee
+++ b/app/coffee/BucketController.coffee
@@ -9,7 +9,7 @@ module.exports = BucketController =
 	getFile: (req, res)->
 		{bucket} = req.params
 		key = req.params[0]
-		credentials = settings.filestore.s3[bucket]
+		credentials = settings.filestore.s3?[bucket]
 		options = {
 			key: key,
 			bucket: bucket,

--- a/app/coffee/BucketController.coffee
+++ b/app/coffee/BucketController.coffee
@@ -10,7 +10,7 @@ module.exports = BucketController =
 		{bucket} = req.params
 		key = req.params[0]
 		{format, style} = req.query
-		credentials = settings.filestore.s3&[bucket]
+		credentials = settings.filestore.s3[bucket]
 		options = {
 			key: key,
 			bucket: bucket,

--- a/app/coffee/BucketController.coffee
+++ b/app/coffee/BucketController.coffee
@@ -1,0 +1,36 @@
+PersistorManager = require("./PersistorManager")
+settings = require("settings-sharelatex")
+logger = require("logger-sharelatex")
+FileHandler = require("./FileHandler")
+metrics = require("metrics-sharelatex")
+parseRange = require('range-parser')
+Errors = require('./Errors')
+
+oneDayInSeconds = 60 * 60 * 24
+maxSizeInBytes = 1024 * 1024 * 1024 # 1GB
+
+module.exports = BucketController =
+
+	getFile: (req, res)->
+		{bucket} = req
+		key = req[0]
+		{format, style} = req.query
+		credentials = settings.filestore.s3&[bucket]
+		options = {
+			key: key,
+			bucket: bucket,
+			credentials: credentials
+		}
+		metrics.inc "getFile"
+		logger.log key:key, bucket:bucket, "receiving request to get file from bucket"
+		FileHandler.getFile bucket, key, options, (err, fileStream)->
+			if err?
+				logger.err err:err, key:key, bucket:bucket, format:format, style:style, "problem getting file from bucket"
+				if err instanceof Errors.NotFoundError
+					return res.send 404
+				else
+					return res.send 500
+			else
+				logger.log key:key, bucket:bucket, format:format, style:style, "sending bucket file to response"
+				fileStream.pipe res
+

--- a/app/coffee/BucketController.coffee
+++ b/app/coffee/BucketController.coffee
@@ -9,7 +9,7 @@ module.exports = BucketController =
 	getFile: (req, res)->
 		{bucket} = req.params
 		key = req.params[0]
-		credentials = settings.filestore.s3?[bucket]
+		credentials = settings.filestore.s3BucketCreds?[bucket]
 		options = {
 			key: key,
 			bucket: bucket,

--- a/app/coffee/S3PersistorManager.coffee
+++ b/app/coffee/S3PersistorManager.coffee
@@ -68,8 +68,8 @@ module.exports =
 		callback = _.once callback
 		logger.log bucketName:bucketName, key:key, "getting file from s3"
 		s3Client = knox.createClient
-			key: settings.filestore.s3.key
-			secret: settings.filestore.s3.secret
+			key: opts.credentials?.auth_key || settings.filestore.s3.key
+			secret: opts.credentials?.auth_secret || settings.filestore.s3.secret
 			bucket: bucketName
 		s3Stream = s3Client.get(key, headers)
 		s3Stream.end()

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -25,12 +25,16 @@ module.exports =
 			template_files: Path.resolve(__dirname + "/../template_files")
 		# if you are using S3, then fill in your S3 details below
 		# s3:
-		# 	key: ""
-		# 	secret: ""
+		# 	key: ""     # default
+		# 	secret: ""  # default
+		#   bucketname1: # secrets for bucketname1
+		#     auth_key: ""
+		#     auth_secret: ""
+		#  bucketname2: # secrets for bucketname2...
 
 	path:
 		uploadFolder: Path.resolve(__dirname + "/../uploads")
-		
+
 	commands:
 		# Any commands to wrap the convert utility in, for example ["nice"], or ["firejail", "--profile=/etc/firejail/convert.profile"]
 		convertCommandPrefix: []

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -28,11 +28,14 @@ module.exports =
 		# s3:
 		# 	key: ""     # default
 		# 	secret: ""  # default
+		#
+		# s3BucketCreds:
 		#   bucketname1: # secrets for bucketname1
 		#     auth_key: ""
 		#     auth_secret: ""
 		#  bucketname2: # secrets for bucketname2...
-		s3: JSON.parse process.env['S3_CREDENTIALS'] if process.env['S3_CREDENTIALS']
+
+		s3BucketCreds: JSON.parse process.env['S3_BUCKET_CREDENTIALS'] if process.env['S3_BUCKET_CREDENTIALS']
 
 	path:
 		uploadFolder: Path.resolve(__dirname + "/../uploads")

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -23,7 +23,8 @@ module.exports =
 			user_files: Path.resolve(__dirname + "/../user_files")
 			public_files: Path.resolve(__dirname + "/../public_files")
 			template_files: Path.resolve(__dirname + "/../template_files")
-		# if you are using S3, then fill in your S3 details below
+		# if you are using S3, then fill in your S3 details below,
+		# or use env var with the same structure.
 		# s3:
 		# 	key: ""     # default
 		# 	secret: ""  # default
@@ -31,6 +32,7 @@ module.exports =
 		#     auth_key: ""
 		#     auth_secret: ""
 		#  bucketname2: # secrets for bucketname2...
+		s3: JSON.parse process.env['S3_CREDENTIALS'] if process.env['S3_CREDENTIALS']
 
 	path:
 		uploadFolder: Path.resolve(__dirname + "/../uploads")

--- a/test/unit/coffee/BucketControllerTests.coffee
+++ b/test/unit/coffee/BucketControllerTests.coffee
@@ -43,9 +43,10 @@ describe "BucketController", ->
 		@bucket = "user_files"
 		@key = "#{@project_id}/#{@file_id}"
 		@req =
-			bucket:@bucket
-			0:@key
 			query:{}
+			params:
+				bucket: @bucket
+				0: @key
 			headers: {}
 		@res =
 			setHeader: ->

--- a/test/unit/coffee/BucketControllerTests.coffee
+++ b/test/unit/coffee/BucketControllerTests.coffee
@@ -1,0 +1,68 @@
+assert = require("chai").assert
+sinon = require('sinon')
+chai = require('chai')
+should = chai.should()
+expect = chai.expect
+modulePath = "../../../app/js/BucketController.js"
+SandboxedModule = require('sandboxed-module')
+
+describe "BucketController", ->
+
+	beforeEach ->
+		@PersistorManager =
+			sendStream: sinon.stub()
+			copyFile: sinon.stub()
+			deleteFile:sinon.stub()
+
+		@settings =
+			s3:
+				buckets:
+					user_files:"user_files"
+			filestore:
+				backend: "s3"
+				s3:
+					secret: "secret"
+					key: "this_key"
+
+		@FileHandler =
+			getFile: sinon.stub()
+			deleteFile: sinon.stub()
+			insertFile: sinon.stub()
+			getDirectorySize: sinon.stub()
+		@LocalFileWriter = {}
+		@controller = SandboxedModule.require modulePath, requires:
+			"./LocalFileWriter":@LocalFileWriter
+			"./FileHandler": @FileHandler
+			"./PersistorManager":@PersistorManager
+			"settings-sharelatex": @settings
+			"logger-sharelatex":
+				log:->
+				err:->
+		@project_id = "project_id"
+		@file_id = "file_id"
+		@bucket = "user_files"
+		@key = "#{@project_id}/#{@file_id}"
+		@req =
+			bucket:@bucket
+			0:@key
+			query:{}
+			headers: {}
+		@res =
+			setHeader: ->
+		@fileStream = {}
+
+	describe "getFile", ->
+
+		it "should pipe the stream", (done)->
+			@FileHandler.getFile.callsArgWith(3, null, @fileStream)
+			@fileStream.pipe = (res)=>
+				res.should.equal @res
+				done()
+			@controller.getFile @req, @res
+
+		it "should send a 500 if there is a problem", (done)->
+			@FileHandler.getFile.callsArgWith(3, "error")
+			@res.send = (code)=>
+				code.should.equal 500
+				done()
+			@controller.getFile @req, @res

--- a/test/unit/coffee/S3PersistorManagerTests.coffee
+++ b/test/unit/coffee/S3PersistorManagerTests.coffee
@@ -55,6 +55,41 @@ describe "S3PersistorManagerTests", ->
 			@stubbedKnoxClient.get.calledWith(@key).should.equal true
 			done()
 
+		it "should use default auth", (done)->
+			@stubbedKnoxClient.get.returns(
+				on:->
+				end:->
+			)
+			@S3PersistorManager.getFileStream @bucketName, @key, @opts, (err)=> # empty callback
+			clientParams =
+				key: @settings.filestore.s3.key
+				secret: @settings.filestore.s3.secret
+				bucket: @bucketName
+			@knox.createClient.calledWith(clientParams).should.equal true
+			done()
+
+		describe "with supplied auth", ->
+			beforeEach ->
+				@S3PersistorManager = SandboxedModule.require modulePath, requires: @requires
+				@credentials =
+					auth_key: "that_key"
+					auth_secret: "that_secret"
+				@opts =
+					credentials: @credentials
+
+			it "should use supplied auth", (done)->
+				@stubbedKnoxClient.get.returns(
+					on:->
+					end:->
+				)
+				@S3PersistorManager.getFileStream @bucketName, @key, @opts, (err)=> # empty callback
+				clientParams =
+					key: @credentials.auth_key
+					secret: @credentials.auth_secret
+					bucket: @bucketName
+				@knox.createClient.calledWith(clientParams).should.equal true
+				done()
+
 		describe "with start and end options", ->
 			beforeEach ->
 				@opts =

--- a/test/unit/coffee/SettingsTests.coffee
+++ b/test/unit/coffee/SettingsTests.coffee
@@ -1,0 +1,22 @@
+assert = require("chai").assert
+sinon = require('sinon')
+chai = require('chai')
+should = chai.should()
+expect = chai.expect
+modulePath = "../../../app/js/BucketController.js"
+SandboxedModule = require('sandboxed-module')
+
+describe "Settings", ->
+	describe "s3", ->
+		it "should use JSONified env var if present", (done)->
+			s3_settings =
+				key: 'default_key'
+				secret: 'default_secret'
+				bucket1:
+					auth_key: 'bucket1_key'
+					auth_secret: 'bucket1_secret'
+			process.env['S3_CREDENTIALS'] = JSON.stringify s3_settings
+
+			settings =require('settings-sharelatex')
+			expect(settings.filestore.s3).to.deep.equal s3_settings
+			done()


### PR DESCRIPTION
Add `/bucket/:bucket/key/*`, which fetches the file from the given bucket at the given path. Uses auth stored at `settings.filestore.s3.{{bucketName}}` if present, and otherwise default auth.

This is to support the use case where:
- v1 makes a CLSI request to v2, 
    and
- request contains file URLs stored on S3, 
    and
- they are not in the default bucket that v2 would use for its own files, 
    and
- CLSI is in a contained environment and cannot reach S3 except through filestore.

Child of https://github.com/overleaf/sharelatex/issues/664
Child of https://github.com/overleaf/sharelatex/issues/507