### PR TITLE
add dockerfile to install packages needed by filestore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:6.9.5
+
+RUN apt-get update
+# we also need imagemagick but it is already in the node docker image
+RUN apt-get install -y --no-install-recommends ghostscript optipng


### PR DESCRIPTION
In the dev environment the image conversions currently don't work due to missing packages for `ghostscript` and `optipng`.  This adds a project-specific docker file to install them.