### PR TITLE
make filestore backends consistent

### DIFF
--- a/app/coffee/S3PersistorManager.coffee
+++ b/app/coffee/S3PersistorManager.coffee
@@ -42,9 +42,8 @@ module.exports =
 			if res.statusCode != 200
 				logger.err bucketName:bucketName, key:key, fsPath:fsPath, "non 200 response from s3 putting file"
 				return callback("non 200 response from s3 on put file")
-			LocalFileWriter.deleteFile fsPath, (err)->
-				logger.log res:res,  bucketName:bucketName, key:key, fsPath:fsPath,"file uploaded to s3"
-				callback(err)
+			logger.log res:res,  bucketName:bucketName, key:key, fsPath:fsPath,"file uploaded to s3"
+			callback(err)
 		putEventEmiter.on "error", (err)->
 			logger.err err:err,  bucketName:bucketName, key:key, fsPath:fsPath, "error emmited on put of file"
 			callback err
@@ -57,7 +56,10 @@ module.exports =
 			if err?
 				logger.err  bucketName:bucketName, key:key, fsPath:fsPath, err:err, "something went wrong writing stream to disk"
 				return callback(err)
-			@sendFile bucketName, key, fsPath, callback
+			@sendFile bucketName, key, fsPath, (err) ->
+				# delete the temporary file created above and return the original error
+				LocalFileWriter.deleteFile fsPath, () ->
+					callback(err)
 
 	# opts may be {start: Number, end: Number}
 	getFileStream: (bucketName, key, opts, callback = (err, res)->)->

--- a/test/unit/coffee/FSPersistorManagerTests.coffee
+++ b/test/unit/coffee/FSPersistorManagerTests.coffee
@@ -25,6 +25,7 @@ describe "FSPersistorManagerTests", ->
     @Rimraf = sinon.stub()
     @LocalFileWriter =
       writeStream: sinon.stub()
+      deleteFile: sinon.stub()
     @requires =
       "./LocalFileWriter":@LocalFileWriter
       "fs":@Fs
@@ -43,10 +44,32 @@ describe "FSPersistorManagerTests", ->
     @FSPersistorManager = SandboxedModule.require modulePath, requires: @requires
 
   describe "sendFile", ->
-    it "should put the file", (done) ->
-      @Fs.rename.callsArgWith(2,@error)
+    beforeEach ->
+      @Fs.createReadStream = sinon.stub().returns({
+        on: ->
+        pipe: ->
+      })
+
+    it "should copy the file", (done) ->
+      @Fs.createWriteStream =sinon.stub().returns({
+        on: (event, handler) ->
+          process.nextTick(handler) if event is 'finish'
+      })
       @FSPersistorManager.sendFile @location, @name1, @name2, (err)=>
-        @Fs.rename.calledWith( @name2, "#{@location}/#{@name1Filtered}" ).should.equal true
+        @Fs.createReadStream.calledWith(@name2).should.equal true
+        @Fs.createWriteStream.calledWith("#{@location}/#{@name1Filtered}" ).should.equal true
+        done()
+
+    it "should return an error if the file cannot be stored", (done) ->
+      @Fs.createWriteStream =sinon.stub().returns({
+        on: (event, handler) =>
+         if event is 'error'
+          process.nextTick () =>
+            handler(@error)
+      })
+      @FSPersistorManager.sendFile @location, @name1, @name2, (err)=>
+        @Fs.createReadStream.calledWith(@name2).should.equal true
+        @Fs.createWriteStream.calledWith("#{@location}/#{@name1Filtered}" ).should.equal true
         err.should.equal @error
         done()
 
@@ -54,6 +77,7 @@ describe "FSPersistorManagerTests", ->
     beforeEach ->
       @FSPersistorManager.sendFile = sinon.stub().callsArgWith(3)
       @LocalFileWriter.writeStream.callsArgWith(2, null, @name1)
+      @LocalFileWriter.deleteFile.callsArg(1)
       @SourceStream =
         on:->
 


### PR DESCRIPTION
Currently the different filestore backends `FSPersistor`, `AWSSDKPersistor` and `S3Persistor` have different behaviours for `sendFile` and `sendStream`, with regard to deleting the uploaded file and/or temporary files that they create.

This PR makes them consistent as follows:

- `sendFile` (which  uploads a supplied file to S3) should not delete the original file, leaving that the the caller.
- `sendStream` (which uploads a stream to S3, which is done by storing it as a file and then calling `sendFile`) should delete the temporary file it creates.

The previous logic was

| Module | `sendFile` | `sendStream` |
| ------------ | -- | ---| 
| FSPersistor |   deletes input file | leaves temporary file in upload directory |
| S3Persistor | deletes input file |  deletes temporary file by calling `sendFile` |
| AWSSDKPersistor | leaves input file | does not create temporary file |

The reason for doing this is that to because of problems with read-after-write consistency we want to always have a copy of the input file to serve back to the client after uploading it 