### PR TITLE
serve file from disk to avoid read-after-write inconsistency

### DIFF
--- a/app/coffee/LocalFileWriter.coffee
+++ b/app/coffee/LocalFileWriter.coffee
@@ -5,6 +5,7 @@ _ = require("underscore")
 logger = require("logger-sharelatex")
 metrics = require("metrics-sharelatex")
 Settings = require("settings-sharelatex")
+Errors = require "./Errors"
 
 module.exports = 
 
@@ -25,6 +26,22 @@ module.exports =
 			logger.log err:err, fsPath:fsPath, "problem writing file locally, with read stream"
 			callback err
 		stream.pipe writeStream
+
+	getStream: (fsPath, _callback = (err, res)->) ->
+		callback = _.once _callback
+		timer = new metrics.Timer("readingFile")
+		logger.log fsPath:fsPath, "reading file locally"
+		readStream = fs.createReadStream(fsPath)
+		readStream.on "end", ->
+			timer.done()
+			logger.log fsPath:fsPath, "finished reading file locally"
+		readStream.on "error", (err)->
+			logger.err err:err, fsPath:fsPath, "problem reading file locally, with read stream"
+			if err.code == 'ENOENT'
+				callback new Errors.NotFoundError(err.message), null
+			else
+				callback err
+		callback null, readStream
 
 	deleteFile: (fsPath, callback)->
 		if !fsPath? or fsPath == ""

--- a/test/unit/coffee/FileHandlerTests.coffee
+++ b/test/unit/coffee/FileHandlerTests.coffee
@@ -23,6 +23,7 @@ describe "FileHandler", ->
 			directorySize: sinon.stub()
 		@LocalFileWriter =
 			writeStream: sinon.stub()
+			getStream: sinon.stub()
 			deleteFile: sinon.stub()
 		@FileConverter =
 			convert: sinon.stub()
@@ -152,17 +153,20 @@ describe "FileHandler", ->
 
 		it "should _convertFile ", (done)->
 			@stubbedStream = {"something":"here"}
+			@localStream = {
+				on: ->
+			}
 			@PersistorManager.sendFile = sinon.stub().callsArgWith(3)
-			@PersistorManager.getFileStream = sinon.stub().callsArgWith(3, null, @stubbedStream)
+			@LocalFileWriter.getStream = sinon.stub().callsArgWith(1, null, @localStream)
 			@convetedKey = @key+"converted"
 			@handler._convertFile = sinon.stub().callsArgWith(3, null, @stubbedPath)
 			@ImageOptimiser.compressPng = sinon.stub().callsArgWith(1)
 			@handler._getConvertedFileAndCache @bucket, @key, @convetedKey, {}, (err, fsStream)=>
 				@handler._convertFile.called.should.equal true
 				@PersistorManager.sendFile.calledWith(@bucket, @convetedKey, @stubbedPath).should.equal true
-				@PersistorManager.getFileStream.calledWith(@bucket, @convetedKey).should.equal true
 				@ImageOptimiser.compressPng.calledWith(@stubbedPath).should.equal true
-				fsStream.should.equal @stubbedStream
+				@LocalFileWriter.getStream.calledWith(@stubbedPath).should.equal true
+				fsStream.should.equal @localStream
 				done()
 
 	describe "_convertFile", ->

--- a/test/unit/coffee/LocalFileWriterTests.coffee
+++ b/test/unit/coffee/LocalFileWriterTests.coffee
@@ -15,8 +15,11 @@ describe "LocalFileWriter", ->
 			on: (type, cb)->
 				if type == "finish"
 					cb()
+		@readStream = 
+			on: ->
 		@fs = 
 			createWriteStream : sinon.stub().returns(@writeStream)
+			createReadStream: sinon.stub().returns(@readStream)
 			unlink: sinon.stub()
 		@settings =
 			path:
@@ -49,6 +52,18 @@ describe "LocalFileWriter", ->
 						cb()
 			@writer.writeStream stream, null, (err, fsPath)=>
 				fsPath.should.equal @stubbedFsPath
+				done()
+
+	describe "getStream", ->
+
+		it "should read the stream from the file ", (done)->
+			@writer.getStream @stubbedFsPath, (err, stream)=>
+				@fs.createReadStream.calledWith(@stubbedFsPath).should.equal true
+				done()
+
+		it "should send the stream in the callback", (done)->
+			@writer.getStream @stubbedFsPath, (err, readStream)=>
+				readStream.should.equal @readStream
 				done()
 
 	describe "delete file", ->


### PR DESCRIPTION
When we write a converted file to S3 we immediately try to read it back, but this violates the conditions for read-after-write consistency because we earlier check if the file exists (https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel).

In this case we want to serve the original file back to the user from disk, and serve the file contents on disk for subsequent requests.

(To work properly in all cases I had to make the backends consistent in https://github.com/sharelatex/filestore-sharelatex/pull/34)
