### PR TITLE
reduce logging of not found errors

### DIFF
--- a/app/coffee/FileController.coffee
+++ b/app/coffee/FileController.coffee
@@ -29,10 +29,10 @@ module.exports = FileController =
 			logger.log start: range.start, end: range.end, "getting range of bytes from file"
 		FileHandler.getFile bucket, key, options, (err, fileStream)->
 			if err?
-				logger.err err:err, key:key, bucket:bucket, format:format, style:style, "problem getting file"
 				if err instanceof Errors.NotFoundError
 					return res.send 404
 				else
+					logger.err err:err, key:key, bucket:bucket, format:format, style:style, "problem getting file"
 					return res.send 500
 			else if req.query.cacheWarm
 				logger.log key:key, bucket:bucket, format:format, style:style, "request is only for cache warm so not sending stream"

--- a/app/coffee/FileHandler.coffee
+++ b/app/coffee/FileHandler.coffee
@@ -6,6 +6,7 @@ FileConverter = require("./FileConverter")
 KeyBuilder = require("./KeyBuilder")
 async = require("async")
 ImageOptimiser = require("./ImageOptimiser")
+Errors = require('./Errors')
 
 module.exports = FileHandler =
 
@@ -32,7 +33,7 @@ module.exports = FileHandler =
 
 	_getStandardFile: (bucket, key, opts, callback)->
 		PersistorManager.getFileStream bucket, key, opts, (err, fileStream)->
-			if err?
+			if err? and !(err instanceof Errors.NotFoundError)
 				logger.err  bucket:bucket, key:key, opts:FileHandler._scrubSecrets(opts), "error getting fileStream"
 			callback err, fileStream
 

--- a/app/coffee/S3PersistorManager.coffee
+++ b/app/coffee/S3PersistorManager.coffee
@@ -74,7 +74,9 @@ module.exports =
 		s3Stream = s3Client.get(key, headers)
 		s3Stream.end()
 		s3Stream.on 'response', (res) ->
-			if res.statusCode == 404
+			if res.statusCode in [403, 404]
+				# S3 returns a 403 instead of a 404 when the user doesn't have
+				# permission to list the bucket contents.
 				logger.log bucketName:bucketName, key:key, "file not found in s3"
 				return callback new Errors.NotFoundError("File not found in S3: #{bucketName}:#{key}"), null
 			if res.statusCode not in [200, 206]


### PR DESCRIPTION
We are logging huge numbers of `Not Found` errors from loading templates which either don't have thumbnails (the creation of the thumbnail failed for some reason) or the template pdf wasn't uploaded. We can at least suppress these from sentry by not logging them as errors.