### PR TITLE
avoid problems with caching of apt-get operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:6.9.5
 
-RUN apt-get update
 # we also need imagemagick but it is already in the node docker image
-RUN apt-get install -y --no-install-recommends ghostscript optipng
+RUN apt-get update && apt-get install -y --no-install-recommends ghostscript optipng


### PR DESCRIPTION
The update and install lines need to be run together, because `RUN apt-get update` is cached in other builds and may be out of date.