### PR TITLE
use the aws sdk to copy files in S3PersistorManager

### DIFF
--- a/app/coffee/S3PersistorManager.coffee
+++ b/app/coffee/S3PersistorManager.coffee
@@ -11,6 +11,7 @@ path = require("path")
 LocalFileWriter = require("./LocalFileWriter")
 Errors = require("./Errors")
 _ = require("underscore")
+awsS3 = require "aws-sdk/clients/s3"
 
 thirtySeconds = 30 * 1000
 
@@ -24,6 +25,12 @@ buildDefaultOptions = (bucketName, method, key)->
 			timeout: thirtySeconds
 			uri:"https://#{bucketName}.s3.amazonaws.com/#{key}"
 	}
+
+s3 = new awsS3({
+	credentials:
+		accessKeyId: settings.filestore.s3.key,
+		secretAccessKey: settings.filestore.s3.secret
+})
 
 module.exports =
 
@@ -90,12 +97,10 @@ module.exports =
 			callback err
 
 	copyFile: (bucketName, sourceKey, destKey, callback)->
-		logger.log bucketName:bucketName, sourceKey:sourceKey, destKey:destKey, "copying file in s3"
-		s3Client = knox.createClient
-			key: settings.filestore.s3.key
-			secret: settings.filestore.s3.secret
-			bucket: bucketName
-		s3Client.copyFile sourceKey, destKey, (err)->
+		logger.log bucketName:bucketName, sourceKey:sourceKey, destKey: destKey, "copying file in s3"
+		source = bucketName + '/' + sourceKey
+		# use the AWS SDK instead of knox due to problems with error handling (https://github.com/Automattic/knox/issues/114)
+		s3.copyObject {Bucket: bucketName, Key: destKey, CopySource: source}, (err) ->
 			if err?
 				logger.err err:err, bucketName:bucketName, sourceKey:sourceKey, destKey:destKey, "something went wrong copying file in aws"
 			callback(err)

--- a/test/unit/coffee/S3PersistorManagerTests.coffee
+++ b/test/unit/coffee/S3PersistorManagerTests.coffee
@@ -25,11 +25,15 @@ describe "S3PersistorManagerTests", ->
 			get: sinon.stub()
 		@knox =
 			createClient: sinon.stub().returns(@stubbedKnoxClient)
+		@stubbedS3Client =
+			copyObject:sinon.stub()
+		@awsS3 = sinon.stub().returns @stubbedS3Client
 		@LocalFileWriter =
 			writeStream: sinon.stub()
 			deleteFile: sinon.stub()
 		@requires =
 			"knox": @knox
+			"aws-sdk/clients/s3": @awsS3
 			"settings-sharelatex": @settings
 			"./LocalFileWriter":@LocalFileWriter
 			"logger-sharelatex":
@@ -207,11 +211,11 @@ describe "S3PersistorManagerTests", ->
 			@destKey = "my/dest/key"
 			@S3PersistorManager = SandboxedModule.require modulePath, requires: @requires
 
-		it "should use knox to copy file", (done)->
-			@stubbedKnoxClient.copyFile.callsArgWith(2, @error)
+		it "should use AWS SDK to copy file", (done)->
+			@stubbedS3Client.copyObject.callsArgWith(1, @error)
 			@S3PersistorManager.copyFile @bucketName, @sourceKey, @destKey, (err)=>
 				err.should.equal @error
-				@stubbedKnoxClient.copyFile.calledWith(@sourceKey, @destKey).should.equal true
+				@stubbedS3Client.copyObject.calledWith({Bucket: @bucketName, Key: @destKey, CopySource: @bucketName + '/' + @key}).should.equal true
 				done()
 
 	describe "deleteDirectory", ->


### PR DESCRIPTION
to work around problems with knox error handling making the S3 copy operation unreliable.

I have tested this locally using the staging s3 credentials.  Only replacing the copy operation at this stage, as it is the only one which we have encountered actual problems with.  The other operations can be migrated to the AWS SDK later.

connects to https://github.com/overleaf/sharelatex/issues/1225