### PR TITLE
Disable exec with settings flag

### DIFF
--- a/app/coffee/ImageOptimiser.coffee
+++ b/app/coffee/ImageOptimiser.coffee
@@ -1,5 +1,6 @@
 exec = require('child_process').exec
 logger = require("logger-sharelatex")
+Settings = require "settings-sharelatex"
 
 module.exports = 
 
@@ -10,6 +11,9 @@ module.exports =
 		opts =
 			timeout: 30 * 1000
 			killSignal: "SIGKILL"
+		if !Settings.enableConversions
+			error = new Error("Image conversions are disabled")
+			return callback(error)
 		exec args, opts,(err, stdout, stderr)->
 			if err? and err.signal == 'SIGKILL'
 				logger.warn {err: err, stderr: stderr, localPath: localPath}, "optimiser timeout reached"

--- a/app/coffee/SafeExec.coffee
+++ b/app/coffee/SafeExec.coffee
@@ -1,6 +1,7 @@
 _ = require("underscore")
 logger = require("logger-sharelatex")
 child_process = require('child_process')
+Settings = require "settings-sharelatex"
 
 # execute a command in the same way as 'exec' but with a timeout that
 # kills all child processes
@@ -9,6 +10,10 @@ child_process = require('child_process')
 # group, then we can kill everything in that process group.
 
 module.exports = (command, options, callback = (err, stdout, stderr) ->) ->
+	if !Settings.enableConversions
+		error = new Error("Image conversions are disabled")
+		return callback(error)
+
 	# options are {timeout:  number-of-milliseconds, killSignal: signal-name}
 	[cmd, args...] = command
 

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -50,6 +50,7 @@ settings =
 		# Any commands to wrap the convert utility in, for example ["nice"], or ["firejail", "--profile=/etc/firejail/convert.profile"]
 		convertCommandPrefix: []
 
+	enableConversions: false
 
 # Filestore health check
 # ----------------------

--- a/test/unit/coffee/SafeExecTests.coffee
+++ b/test/unit/coffee/SafeExecTests.coffee
@@ -9,11 +9,13 @@ SandboxedModule = require('sandboxed-module')
 describe "SafeExec", ->
 
 	beforeEach ->
-
+		@settings = 
+			enableConversions:true
 		@safe_exec = SandboxedModule.require modulePath, requires:
 			"logger-sharelatex":
 				log:->
 				err:->
+			"settings-sharelatex": @settings
 		@options = {timeout: 10*1000, killSignal: "SIGTERM" }
 
 	describe "safe_exec", ->
@@ -22,6 +24,12 @@ describe "SafeExec", ->
 			@safe_exec ["/bin/echo", "hello"], @options, (err, stdout, stderr) =>
 				stdout.should.equal "hello\n"
 				should.not.exist(err)
+				done()
+
+		it "should error when conversions are disabled", (done) ->
+			@settings.enableConversions = false
+			@safe_exec ["/bin/echo", "hello"], @options, (err, stdout, stderr) =>
+				expect(err).to.exist
 				done()
 
 		it "should execute a command with non-zero exit status", (done) ->


### PR DESCRIPTION
We can't really trust the convert commands in filestore on k8 due to lack of firejail sandboxing, this flag hard disables there functionality until we have a better system available. I've not checked on user facing impact of previewing `eps` and `pdf` image in the editor yet, this PR is just for security reasons.

Child of https://github.com/overleaf/sharelatex/issues/552