### PR TITLE
fix beginShutdown to use server.close()

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -117,7 +117,7 @@ beginShutdown = () ->
 			process.exit 1
 		, 120*1000
 		killTimer.unref?() # prevent timer from keeping process alive
-		app.close () ->
+		server.close () ->
 			logger.log "closed all connections"
 			Metrics.close()
 			process.disconnect?()
@@ -128,7 +128,7 @@ port = settings.internal.filestore.port or 3009
 host = "0.0.0.0"
 
 if !module.parent # Called directly
-	app.listen port, host, (error) ->
+	server = app.listen port, host, (error) ->
 		logger.info "Filestore starting up, listening on #{host}:#{port}"
 
 


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Noticed this error in the google logs, the `close` method is actually on the `server` object.

```
filestore_1               | /app/app.js:167
filestore_1               |       app.close(function() {
filestore_1               |           ^
filestore_1               | 
filestore_1               | TypeError: app.close is not a function
filestore_1               |     at beginShutdown (/app/app.js:167:11)
filestore_1               |     at process.<anonymous> (/app/app.js:192:12)
filestore_1               |     at emitNone (events.js:86:13)
filestore_1               |     at process.emit (events.js:185:7)
filestore_1               |     at Signal.wrap.onsignal (internal/process.js:199:44)
```

#### Screenshots

NA

#### Related Issues / PRs

NA

### Review

2 line change

#### Potential Impact

Low

#### Manual Testing Performed

- [X]  Tested sending SIGTERM to process locally

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

@henryoswald @mans0954 